### PR TITLE
2.1.0 - Now supports Italian dates and times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - German Internationalization
-- Italian Internationalization
+
+## [2.1.0] - 2024-01-07
+
+### Added
+
+- Now supports Italian dates and times.
 
 ## [2.0.2] - 2024-01-07
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # accessible-date
 
-**accessible-date** is an npm module that creates readable, accessible dates for screen readers. These dates are returned in Coordinated Universal Time (UTC), and are currently available in English, Spanish, and French with more languages to come.
+**accessible-date** is an npm module that creates readable, accessible dates for screen readers. These dates are returned in Coordinated Universal Time (UTC), and are currently available in English, Spanish, French, and Italian with more languages to come.
 
 Screen readers have a hard time deciphering what is and isn’t a date in HTML. For example, if a screen reader comes across the following timestamp:
 
@@ -83,7 +83,7 @@ How the returned string is formatted. You can use any combination of the followi
 - `m` - Meridian (ex: “A M,” “P M”)
 
 `settings.language` - ***default*** `en`
-Set the language you want the output to be formatted to. Currently, it supports English (`en`), Spanish (`es`), and French (`fr`), but more languages will continue to be added.
+Set the language you want the output to be formatted to. Currently, it supports English (`en`), Spanish (`es`), French (`fr`), and Italian (`it`), but more languages will continue to be added.
 
 `settings.military` - ***default*** `false`
 If set to `true`, date will display in military time. Otherwise, it defaults to displaying in standard time.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
     "french"
   ],
   "author": "Barry Horbal <barry@barryhorbal.com>",
+  "contributors": [
+    {
+      "name": "Fabrizio Guerra",
+      "url": "https://github.com/frammentigrafici"
+    }
+  ],
   "license": "MIT",
   "devDependencies": {
     "@babel/cli": "^7.23.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessible-date",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Readable, accessible dates for screen readers.",
   "main": "dist/accessible-date.js",
   "repository": {

--- a/src/accessible-date.js
+++ b/src/accessible-date.js
@@ -7,7 +7,7 @@ export default function accessibleDate(date, options) {
     }
 
     const settings = {
-        supportedLanguages: [`en`, `es`, `fr`],
+        supportedLanguages: [`en`, `es`, `fr`, `it`],
         language: ``,
         military: false,
         format: ``
@@ -29,7 +29,7 @@ export default function accessibleDate(date, options) {
     if (
         options.military &&
         typeof options.military === `boolean` &&
-        !settings.language.match(/es|fr/)
+        !settings.language.match(/es|fr|it/)
     ) {
         settings.military = options.military;
     }
@@ -40,7 +40,8 @@ export default function accessibleDate(date, options) {
         day: {
             en: [`Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`],
             es: [`domingo`, `lunes`, `martes`, `miércoles`, `jueves`, `viernes`, `sábado`],
-            fr: [`dimanche`, `lundi`, `mardi`, `mercredi`, `jeudi`, `vendredi`, `samedi`]
+            fr: [`dimanche`, `lundi`, `mardi`, `mercredi`, `jeudi`, `vendredi`, `samedi`],
+            it: [`domenica`, `lunedì`, `martedì`, `mercoledì`, `giovedì`, `venerdì`, `sabato`]
         },
         // Minute (MM)
         minute: {
@@ -53,13 +54,17 @@ export default function accessibleDate(date, options) {
             },
             fr: {
                 standard: [``, `une`, `deux`, `trois`, `quatre`, `cinq`, `six`, `sept`, `huit`, `neuf`, `dix`, `onze`, `douze`, `treize`, `quatorze`, `quinze`, `seize`, `dix-sept`, `dix-huit`, `dix-neuf`, `vingt`, `vingt et un`, `vingt-deux`, `vingt-trois`, `vingt-quatre`, `vingt-cinq`, `vingt-six`, `vingt-sept`, `vingt-huit`, `vingt-neuf`, `trente`, `Trente et un`, `Trente-deux`, `Trente-trois`, `Trente-quatre`, `Trente-cinq`, `Trente-six`, `Trente-sept`, `Trente-huit`, `Trente-neuf`, `quarante`, `quarante et un`, `quarante-deux`, `quarante-trois`, `quarante-quatre`, `quarante-cinq`, `quarante-six`, `quarante-sept`, `quarante-huit`, `quarante-neuf`, `cinquante`, `cinquante et un`, `cinquante-deux`, `cinquante-trois`, `cinquante-quatre`, `cinquante-cinq`, `cinquante-six`, `cinquante-sept`, `cinquante-huit`, `cinquante-neuf`]
-            }
+            },
+            it: {
+                standard: [``, `zero uno`, `zero due`, `zero tre`, `zero quattro`, `zero cinque`, `zero sei`, `zero sette`, `zero otto`, `zero nove`, `dieci`, `undici`, `dodici`, `tredici`, `quattordici`, `quindici`, `sedici`, `diciassette`, `diciotto`, `diciannove`, `venti`, `ventuno`, `ventidue`, `ventitre`, `ventiquattro`, `venticinque`, `ventisei`, `ventisette`, `ventotto`, `ventinove`, `trenta`, `trentuno`, `trentdue`, `trentatre`, `trentaquattro`, `trentacinque`, `trentasei`, `trentasette`, `trentotto`, `trentanove`, `quaranta`, `quarantuno`, `quarantadue`, `quarantatre`, `quarantaquattro`, `quarantacinque`, `quarantasei`, `quarantasette`, `quarantotto`, `quarantanove`, `cinquanta`, `cinquantuno`, `cinquantadue`, `cinquantatre`, `cinquantaquattro`, `cinquantacinque`, `cinquantasei`, `cinquantasette`, `cinquantotto`, `cinquantanove`]
+            },
         },
         // Date (D)
         date: {
             en: [`first`, `second`, `third`, `fourth`, `fifth`, `sixth`, `seventh`, `eigth`, `ninth`, `tenth`, `eleventh`, `twelfth`, `thirteenth`, `fourteenth`, `fifteenth`, `sixteenth`, `seventeenth`, `eighteenth`, `nineteenth`, `twentieth`, `twenty-first`, `twenty-second`, `twenty-third`, `twenty-fourth`, `twenty-fifth`, `twenty-sixth`, `twenty-seventh`, `twenty-eighth`, `twenty-ninth`, `thirtieth`, `thirty-first`],
             es: [`uno`, `dos`, `tres`, `cuatro`, `cinco`, `seis`, `siete`, `ocho`, `nueve`, `diez`, `once`, `doce`, `trece`, `catorce`, `quince`, `dieceseis`, `diecesiete`, `dieceocho`, `diecenueve`, `veinte`, `veintiuno`, `veintidós`, `veintitrés`, `veinticuatro`, `veinticinco`, `veintiséis`, `veintisiete`, `veintiocho`, `veintinueve`, `treinta`, `treinta y uno`],
-            fr: [`une`, `deux`, `trois`, `quatre`, `cinq`, `six`, `sept`, `huit`, `neuf`, `dix`, `onze`, `douze`, `treize`, `quatorze`, `quinze`, `seize`, `dix-sept`, `dix-huit`, `dix-neuf`, `vingt`, `vingt et un`, `vingt-deux`, `vingt-trois`, `vingt-quatre`, `vingt-cinq`, `vingt-six`, `vingt-sept`, `vingt-huit`, `vingt-neuf`, `trente`, `Trente et un`]
+            fr: [`une`, `deux`, `trois`, `quatre`, `cinq`, `six`, `sept`, `huit`, `neuf`, `dix`, `onze`, `douze`, `treize`, `quatorze`, `quinze`, `seize`, `dix-sept`, `dix-huit`, `dix-neuf`, `vingt`, `vingt et un`, `vingt-deux`, `vingt-trois`, `vingt-quatre`, `vingt-cinq`, `vingt-six`, `vingt-sept`, `vingt-huit`, `vingt-neuf`, `trente`, `Trente et un`],
+            it: [ `uno`, `due`, `tre`, `quattro`, `cinque`, `sei`, `sette`, `otto`, `nove`, `dieci`, `undici`, `dodici`, `tredici`, `quattordici`, `quindici`, `sedici`, `diciassette`, `diciotto`, `diciannove`, `venti`, `ventuno`, `ventidue`, `ventitre`, `ventiquattro`, `venticinque`, `ventisei`, `ventisette`, `ventotto`, `ventinove`, `trenta`, `trentuno`]
         },
         // Hour (H)
         hour: {
@@ -72,19 +77,24 @@ export default function accessibleDate(date, options) {
             },
             fr: {
                 standard: [`zéro`, `une`, `deux`, `trois`, `quatre`, `cinq`, `six`, `sept`, `huit`, `neuf`, `dix`, `onze`, `douze`, `treize`, `quatorze`, `quinze`, `seize`, `dix-sept`, `dix-huit`, `dix-neuf`, `vingt`, `vingt et un`, `vingt-deux`, `vingt-trois`]
-            }
+            },
+            it : {
+                standard: [`zero`, `uno`, `due`, `tre`, `quattro`, `cinque`, `sei`, `sette`, `otto`, `nove`, `dieci`, `undici`, `dodici`, `tredici`, `quattordici`, `quindici`, `sedici`, `diciassette`, `diciotto`, `diciannove`, `venti`, `ventuno`, `ventidue`, `ventitre`,]
+            },
         },
         // Month (M)
         month: {
             en: [`January`, `February`, `March`, `April`, `May`, `June`, `July`, `August`, `September`, `October`, `November`, `December`],
             es: [`enero`, `febrero`, `marzo`, `abril`, `mayo`, `junio`, `julio`, `agusto`, `spetiembre`, `octubre`, `noviembre`, `diciembre`],
-            fr: [`janvier`, `février`, `mars`, `avril`, `mai`, `juin`, `juillet`, `août`, `septembre`, `octobre`, `novembre`, `décembre`]
+            fr: [`janvier`, `février`, `mars`, `avril`, `mai`, `juin`, `juillet`, `août`, `septembre`, `octobre`, `novembre`, `décembre`],
+            it: [`gennaio`, `febbraio`, `marzo`, `aprile`, `maggio`, `giugno`, `luglio`, `agosto`, `settembre`, `ottobre`, `novembre`, `dicembre`]
         },
         // Second (S)
         second: {
             en: [`zero`, `one`, `two`, `three`, `four`, `five`, `six`, `seven`, `eight`, `nine`, `ten`, `eleven`, `twelve`, `thirteen`, `fourteen`, `fifteen`, `sixteen`, `seventeen`, `eighteen`, `nineteen`, `twenty`, `twenty-one`, `twenty-two`, `twenty-three`, `twenty-four`, `twenty-five`, `twenty-six`, `twenty-seven`, `twenty-eight`, `twenty-nine`, `thirty`, `thirty-one`, `thirty-two`, `thirty-three`, `thirty-four`, `thirty-five`, `thirty-six`, `thirty-seven`, `thirty-eight`, `thirty-nine`, `fourty`, `fourty-one`, `fourty-two`, `fourty-three`, `fourty-four`, `fourty-five`, `fourty-six`, `fourty-seven`, `fourty-eight`, `fourty-nine`, `fifty`, `fifty-one`, `fifty-two`, `fifty-three`, `fifty-four`, `fifty-five`, `fifty-six`, `fifty-seven`, `fifty-eight`, `fifty-nine`],
             es: [`cero`, `uno`, `dos`, `tres`, `cuatro`, `cinco`, `seis`, `siete`, `ocho`, `nueve`, `diez`, `once`, `doce`, `trece`, `catorce`, `quince`, `dieceseis`, `diecesiete`, `dieceocho`, `diecenueve`, `veinte`, `veintiuno`, `veintidós`, `veintitrés`, `veinticuatro`, `veinticinco`, `veintiséis`, `veintisiete`, `veintiocho`, `veintinueve`, `treinta`, `treinta y uno`, `treinta y dos`, `treinta y tres`, `treinta y cuatro`, `treinta y cinco`, `treinta y seis`, `treinta y siete`, `trienta y ocho`, `treinta y nueve`, `cuarenta`, `cuarenta y uno`, `curatenta y dos`, `cuarenta y trece`, `cuarenta y cuatro`, `cuarenta y cinco`, `cuarenta y seis`, `cuarenta y siete`, `cuarenta y ocho`, `cuarenta y nueve`, `cincuenta`, `cincuenta y uno`, `cincuenta y dos`, `cincuenta y trece`, `cincuenta y cuatro`, `cincuenta y cinco`, `cincuenta y seis`, `cincuenta y siete`, `cincuenta y ocho`, `cincuenta y nueve`],
-            fr: [``, `une`, `deux`, `trois`, `quatre`, `cinq`, `six`, `sept`, `huit`, `neuf`, `dix`, `onze`, `douze`, `treize`, `quatorze`, `quinze`, `seize`, `dix-sept`, `dix-huit`, `dix-neuf`, `vingt`, `vingt et un`, `vingt-deux`, `vingt-trois`, `vingt-quatre`, `vingt-cinq`, `vingt-six`, `vingt-sept`, `vingt-huit`, `vingt-neuf`, `trente`, `Trente et un`, `Trente-deux`, `Trente-trois`, `Trente-quatre`, `Trente-cinq`, `Trente-six`, `Trente-sept`, `Trente-huit`, `Trente-neuf`, `quarante`, `quarante et un`, `quarante-deux`, `quarante-trois`, `quarante-quatre`, `quarante-cinq`, `quarante-six`, `quarante-sept`, `quarante-huit`, `quarante-neuf`, `cinquante`, `cinquante et un`, `cinquante-deux`, `cinquante-trois`, `cinquante-quatre`, `cinquante-cinq`, `cinquante-six`, `cinquante-sept`, `cinquante-huit`, `cinquante-neuf`]
+            fr: [``, `une`, `deux`, `trois`, `quatre`, `cinq`, `six`, `sept`, `huit`, `neuf`, `dix`, `onze`, `douze`, `treize`, `quatorze`, `quinze`, `seize`, `dix-sept`, `dix-huit`, `dix-neuf`, `vingt`, `vingt et un`, `vingt-deux`, `vingt-trois`, `vingt-quatre`, `vingt-cinq`, `vingt-six`, `vingt-sept`, `vingt-huit`, `vingt-neuf`, `trente`, `Trente et un`, `Trente-deux`, `Trente-trois`, `Trente-quatre`, `Trente-cinq`, `Trente-six`, `Trente-sept`, `Trente-huit`, `Trente-neuf`, `quarante`, `quarante et un`, `quarante-deux`, `quarante-trois`, `quarante-quatre`, `quarante-cinq`, `quarante-six`, `quarante-sept`, `quarante-huit`, `quarante-neuf`, `cinquante`, `cinquante et un`, `cinquante-deux`, `cinquante-trois`, `cinquante-quatre`, `cinquante-cinq`, `cinquante-six`, `cinquante-sept`, `cinquante-huit`, `cinquante-neuf`],
+            it: [``, `uno`, `due`, `tre`, `quattro`, `cinque`, `sei`, `sette`, `otto`, `nove`, `dieci`, `undici`, `dodici`, `tredici`, `quattordici`, `quindici`, `sedici`, `diciassette`, `diciotto`, `diciannove`, `venti`, `ventuno`, `ventidue`, `ventitre`, `ventiquattro`, `venticinque`, `ventisei`, `ventisette`, `ventotto`, `ventinove`, `trenta`, `trentuno`, `trentdue`, `trentatre`, `trentaquattro`, `trentacinque`, `trentasei`, `trentasette`, `trentotto`, `trentanove`, `quaranta`, `quarantuno`, `quarantadue`, `quarantatre`, `quarantaquattro`, `quarantacinque`, `quarantasei`, `quarantasette`, `quarantotto`, `quarantanove`, `quarantacinque`, `quarantasei`, `quarantasette`, `quarantotto`, `quarantanove`, `cinquanta`, `cinquantuno`, `cinquantadue`, `cinquantatre`, `cinquantaquattro`, `cinquantacinque`, `cinquantasei`, `cinquantasette`, `cinquantotto`, `cinquantanove`],
         },
         // Year (Y)
         year: {
@@ -99,13 +109,18 @@ export default function accessibleDate(date, options) {
             fr: {
                 century: [``, `cent`, `deux cents`, `trois cents`, `quatre cents`, `cinq cents`, `six cents`, `sept cents`, `huit cents`, `neuf cents`, `mille`, `mille cent`, `mille deux cents`, `mille trois cents`, `mille quatre cents`, `mille cinq cents`, `mille six cents`, `mille sept cents`, `mille huit cents`, `mille neuf cents`, `deux mille`, `deux mille cent`],
                 decade: [``, `une`, `deux`, `trois`, `quatre`, `cinq`, `six`, `sept`, `huit`, `neuf`, `dix`, `onze`, `douze`, `treize`, `quatorze`, `quinze`, `seize`, `dix-sept`, `dix-huit`, `dix-neuf`, `vingt`, `vingt et un`, `vingt-deux`, `vingt-trois`, `vingt-quatre`, `vingt-cinq`, `vingt-six`, `vingt-sept`, `vingt-huit`, `vingt-neuf`, `trente`, `Trente et un`, `Trente-deux`, `Trente-trois`, `Trente-quatre`, `Trente-cinq`, `Trente-six`, `Trente-sept`, `Trente-huit`, `Trente-neuf`, `quarante`, `quarante et un`, `quarante-deux`, `quarante-trois`, `quarante-quatre`, `quarante-cinq`, `quarante-six`, `quarante-sept`, `quarante-huit`, `quarante-neuf`, `cinquante`, `cinquante et un`, `cinquante-deux`, `cinquante-trois`, `cinquante-quatre`, `cinquante-cinq`, `cinquante-six`, `cinquante-sept`, `cinquante-huit`, `cinquante-neuf`, `soixante`, `soixante et un`, `soixante-deux`, `soixante-trois`, `soixante-quatre`, `soixante-cinq`, `soixante-six`, `soixante-sept`, `soixante-huit`, `soixante-neuf`, `soixante-dix`, `soixante-et-onze`, `soixante-douze`, `soixante-treize`, `soixante-quatorze`, `soixante-quinze`, `soixante-seize`, `soixante-dix-sept`, `soixante-dix-huit`, `soixante-dix-neuf`, `quatre-vingts`, `quatre-vingt-un`, `quatre-vingt-deux`, `quatre-vingt-trois`, `quatre-vingt-quatre`, `quatre-vingt-cinq`, `quatre-vingt-six`, `quatre-vingt-sept`, `quatre-vingt-huit`, `quatre-vingt-neuf`, `quatre-vingt-dix`, `quatre-vingt-onze`, `quatre-vingt-douze`, `quatre-vingt-treize`, `quatre-vingt-quatorze`, `quatre-vingt-quinze`, `quatre-vingt-seize`, `quatre-vingt-dix-sept`, `quatre-vingt-dix-huit`, `quatre-vingt-dix-neuf`]
+            },
+            it: {
+                century: [``, `cento`, `duecento`, `trecento`, `quattrocento`, `cinquecento`, `seicento`, `settecento`, `ottocento`, `novecento`, `mille`, `millecento`, `milleduecento`, `milletrecento`, `millequattrocento`, `milleciquecento`, `milleseicento`, `millesettecento`, `milleottocento`, `millenovecento`, `duemila`, `duemilacento`],
+                decade: [``, `uno`, `due`, `tre`, `quattro`, `cinque`, `sei`, `sette`, `otto`, `nove`, `dieci`, `undici`, `dodici`, `tredici`, `quattordici`, `quindici`, `sedici`, `diciassette`, `diciotto`, `diciannove`, `venti`, `ventuno`, `ventidue`, `ventitre`, `ventiquattro`, `venticinque`, `ventisei`, `ventisette`, `ventotto`, `ventinove`, `trenta`, `trentuno`, `trentdue`, `trentatre`, `trentaquattro`, `trentacinque`, `trentasei`, `trentasette`, `trentotto`, `trentanove`, `quaranta`, `quarantuno`, `quarantadue`, `quarantatre`, `quarantaquattro`, `quarantacinque`, `quarantasei`, `quarantasette`, `quarantotto`, `quarantanove`, `quarantacinque`, `quarantasei`, `quarantasette`, `quarantotto`, `quarantanove`, `cinquanta`, `cinquantuno`, `cinquantadue`, `cinquantatre`, `cinquantaquattro`, `cinquantacinque`, `cinquantasei`, `cinquantasette`, `cinquantotto`, `cinquantanove`, `sessanta `, `sessantuno`, `sessantadue`, `sessantatre`, `sessantaquattro`, `sessantacinque`, `sessantasei`, `sessantasette`, `sessantotto`, `sessantanove`, `settanta`,`settantuno`, `settantadue`, `settantatre`, `settantaquattro`, `settantacinque`, `settantasei`, `settantasette`, `settantotto`, `settantanove`, `ottanta`, `ottantuno`, `ottantadue`, `ottantatre`, `ottantaquattro`, `ottantacinque`, `ottantasei`, `ottantasette`, `ottantotto`, `ottantanove`, `novanta`, `novantuno`, `novantadue`, `novantatre`, `novantaquattro`, `novantacinque`, `novantasei`, `novantasette`, `novantotto`, `novantanove`]
             }
         },
         // Meridian (m)
         meridian: {
             en: [`a m`, `p m`],
             es: [`de la mañana`, `de la tarde`],
-            fr: [`du matin`, `du soir`]
+            fr: [`du matin`, `du soir`],
+            it: [`del mattino`, `del pomeriggio`]
         }
     };
 

--- a/test/accessible-date.test.js
+++ b/test/accessible-date.test.js
@@ -176,3 +176,52 @@ describe('The accessible French date should return an accessible string formatte
 		expect(times.isoDateFullDate.noMeridian).toBe('mercredi vingt-cinq mars deux mille quinze à huit heures cinquante-six');
 	});
 });
+
+describe('The accessible Italian date should return an accessible string formatted in', () => {
+	const times = {
+		isoDateTimePM: {},
+		isoDateTimeAM: {},
+		isoDateTimeMillisecons: {},
+		isoDateTimeTimezone: {},
+		isoDateDateOnly: {},
+		isoDateFullDate: {}
+	};
+	beforeEach(() => {
+		times.isoDateTimePM.standard = accessibleDate(time1data, {format: `DD D M Y A H e MM m`, military: false, language: `it`});
+		times.isoDateTimePM.noMeridian = accessibleDate(time1data, {format: `DD D M Y A H e MM`, military: true, language: `it`});
+		times.isoDateTimeAM.standard = accessibleDate(time2data, {format: `DD D M Y A H e MM m`, military: false, language: `it`});
+		times.isoDateTimeAM.noMeridian = accessibleDate(time2data, {format: `DD D M Y A H e MM`, military: true, language: `it`});
+		times.isoDateTimeMillisecons.standard = accessibleDate(time3data, {format: `DD D M Y A H e MM m`, military: false, language: `it`});
+		times.isoDateTimeMillisecons.noMeridian = accessibleDate(time3data, {format: `DD D M Y A H e MM`, military: true, language: `it`});
+		times.isoDateTimeTimezone.standard = accessibleDate(time4data, {format: `DD D M Y A H e MM m`, military: false, language: `it`});
+		times.isoDateTimeTimezone.noMeridian = accessibleDate(time4data, {format: `DD D M Y A H e MM`, military: true, language: `it`});
+		times.isoDateDateOnly.standard = accessibleDate(time5data, {format: `DD D M Y A H e MM m`, military: false, language: `it`});
+		times.isoDateDateOnly.noMeridian = accessibleDate(time5data, {format: `DD D M Y A H e MM`, military: true, language: `it`});
+		times.isoDateFullDate.standard = accessibleDate(time6data, {format: `DD D M Y A H e MM m`, military: false, language: `it`});
+		times.isoDateFullDate.noMeridian = accessibleDate(time6data, {format: `DD D M Y A H e MM`, military: true, language: `it`});
+	});
+    test('ISO Date and Time, PM', () => {
+		expect(times.isoDateTimePM.standard).toBe('martedì quindici maggio duemila uno A diciannove e trenta del pomeriggio');
+		expect(times.isoDateTimePM.noMeridian).toBe('martedì quindici maggio duemila uno A diciannove e trenta');
+	});
+	test('ISO Date and Time, AM', () => {
+		expect(times.isoDateTimeAM.standard).toBe('giovedì trentuno maggio duemila diciotto A sette e trenta del mattino');
+		expect(times.isoDateTimeAM.noMeridian).toBe('giovedì trentuno maggio duemila diciotto A sette e trenta');
+	});
+	test('ISO Date and Time, Milliseconds', () => {
+		expect(times.isoDateTimeMillisecons.standard).toBe('martedì quindici maggio duemila diciotto A diciannove e trenta del pomeriggio');
+		expect(times.isoDateTimeMillisecons.noMeridian).toBe('martedì quindici maggio duemila diciotto A diciannove e trenta');
+	});
+	test('ISO Date and Time, Timezone', () => {
+		expect(times.isoDateTimeTimezone.standard).toBe('giovedì trentuno maggio duemila diciotto A nove e trenta del mattino');
+		expect(times.isoDateTimeTimezone.noMeridian).toBe('giovedì trentuno maggio duemila diciotto A nove e trenta');
+	});
+	test('ISO Date and Time, Date Only', () => {
+		expect(times.isoDateDateOnly.standard).toBe('mercoledì venticinque marzo duemila quindici A zero e del mattino');
+		expect(times.isoDateDateOnly.noMeridian).toBe('mercoledì venticinque marzo duemila quindici A zero e');
+	});
+	test('ISO Date and Time, Full Date', () => {
+		expect(times.isoDateFullDate.standard).toBe('mercoledì venticinque marzo duemila quindici A otto e cinquantasei del mattino');
+		expect(times.isoDateFullDate.noMeridian).toBe('mercoledì venticinque marzo duemila quindici A otto e cinquantasei');
+	});
+});


### PR DESCRIPTION
Thanks to [Fabrizio Guerra](https://github.com/frammentigrafici) for his contributions to adding the Italian language to `accessible-dates`!